### PR TITLE
[FIX] 구독 갱신 시 상태 값 설정 추가

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/domain/Subscription.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Subscription.java
@@ -61,6 +61,7 @@ public class Subscription extends Timestamped {
     }
 
     public void renew(LocalDate startDate, LocalDate expiryDate) {
+        this.status = UserStatus.SUBSCRIPTION;
         this.startDate = startDate;
         this.expiryDate = expiryDate;
     }


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
fix/subscription-status → develop

### 작업 사항
- 계정 보류에서 복구 시, 구독 상태 값 업데이트 추가

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
계정 보류 후 계정 복구 타입으로 notification 재인입 시 확인 필요